### PR TITLE
Fixes bug where comparison could be conducted between different reporttypes

### DIFF
--- a/dashboard/internet_nl_dashboard/models.py
+++ b/dashboard/internet_nl_dashboard/models.py
@@ -498,7 +498,7 @@ class UrlListReport(SeriesOfUrlsReportMixin):  # pylint: disable=too-many-ancest
 
     def get_previous_report_from_this_list(self):
         """
-        Get's the previous report of this list. This is useful for creating comparisons.
+        Gets the previous report of this list. This is useful for creating comparisons.
         If there is no previous report None is returned. Calculation is not included by default because it
         makes sorting very slow. The deferred field is retrieved when requested explicitly with a direct query.
         :return:
@@ -506,6 +506,7 @@ class UrlListReport(SeriesOfUrlsReportMixin):  # pylint: disable=too-many-ancest
         try:
             return UrlListReport.objects.all().filter(
                 urllist=self.urllist,
+                report_type=self.report_type,
                 at_when__lt=self.at_when
             ).exclude(id=self.id).defer('calculation').latest()
         except UrlListReport.DoesNotExist:


### PR DESCRIPTION
There currently exists a bug in the comparison e-mails when using a single urllist for both domain and mail scans. The `get_previous_report_from_this_list` that is used to get the previous report now returns the last used report, but does not check on report type. Since both scans are executed at the same time, the comparison method will always compare to a different report type.

This PR fixes this by including the report type when getting the previous report.

See below the e-mails I received of last scans, the IDs in the mails are of different types.

![image](https://user-images.githubusercontent.com/9413731/181198647-360d3035-24a4-4309-afca-9b6eea8cdf6f.png)

![image](https://user-images.githubusercontent.com/9413731/181198795-711cac4d-b698-4778-b807-a42f1fb8be1a.png)
