### PR TITLE
Suggest subdomains should be a GET interface instead of POST

### DIFF
--- a/dashboard/internet_nl_dashboard/views/domains.py
+++ b/dashboard/internet_nl_dashboard/views/domains.py
@@ -17,9 +17,9 @@ from dashboard.internet_nl_dashboard.views import LOGIN_URL, get_account, get_js
 
 @login_required(login_url=LOGIN_URL)
 def suggest_subdomains_(request) -> JsonResponse:
-    request = get_json_body(request)
-    domain = request.get("domain", "")
-    period = request.get("period", 370)
+    domain = request.GET.get("domain", "")
+    period = request.GET.get("period", 370)
+
     try:
         result = JsonResponse(suggest_subdomains(domain, period), encoder=JSEncoder, safe=False)
     except ValueError:


### PR DESCRIPTION
Makes for easier testing and since it doesn't modify any date using post with json datatype is just a nuisance during
testing/development/debugging