### PR TITLE
fix: video tutorial link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 For quick installation: Follow [these quick instructions](https://github.com/internetstandards/Internet.nl-dashboard/blob/main/docs/render/markdown/1_installation.md) 
-and watch [this 6 minute video](https://github.com/internetstandards/Internet.nl-dashboard/tree/main/docs/input/internet.nl%20dashboard%20installation%20video%20small.mp4).
+and watch [this 6 minute video](https://github.com/internetstandards/Internet.nl-dashboard/raw/refs/heads/main/readme/internet.nl%20dashboard%20installation%20video%20small.mp4).
 
 # Internet.nl Dashboard
 The internet.nl dashboard allows you to visualize batch scans from the internet.nl API. It allows:
@@ -19,7 +19,7 @@ The internet.nl dashboard allows you to visualize batch scans from the internet.
 ## Setup / installation
 
 For quick installation: Follow [these quick instructions](https://github.com/internetstandards/Internet.nl-dashboard/blob/main/docs/render/markdown/1_installation.md) 
-and watch [this 6 minute video](https://github.com/internetstandards/Internet.nl-dashboard/tree/main/docs/input/internet.nl%20dashboard%20installation%20video%20small.mp4).
+and watch [this 6 minute video](https://github.com/internetstandards/Internet.nl-dashboard/raw/refs/heads/main/readme/internet.nl%20dashboard%20installation%20video%20small.mp4).
 
 
 ## Screenshots


### PR DESCRIPTION
The video link in the readme was invalid, this link should download the video directly in the browser of the user since github doesn't play video's